### PR TITLE
Version 0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
-# references:
-# * http://www.objc.io/issue-6/travis-ci.html
-# * https://github.com/supermarin/xcpretty#usage
-
-osx_image: xcode7.3
 language: objective-c
-# cache: cocoapods
-# podfile: Example/Podfile
-# before_install:
-# - gem install cocoapods # Since Travis is not always on latest version
-# - pod install --project-directory=Example
+osx_image: xcode9.2
+branches:
+  only:
+    - master
+
+cache: cocoapods
+podfile: Example/Podfile
+before_install:
+  - gem install cocoapods # Since Travis is not always on latest version
+  - pod install --project-directory=Example
 script:
-- set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/SimpleTableViewWrapper.xcworkspace -scheme SimpleTableViewWrapper-Example -sdk iphonesimulator9.3 ONLY_ACTIVE_ARCH=NO | xcpretty
+- set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/SimpleTableViewWrapper.xcworkspace -scheme SimpleTableViewWrapper-Example -sdk iphonesimulator11.2 ONLY_ACTIVE_ARCH=NO | xcpretty
 - pod lib lint

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		3C6F005E2037081F00D24078 /* STableViewCellProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F00582037081F00D24078 /* STableViewCellProtocol.swift */; };
 		3C6F005F2037081F00D24078 /* STableViewHeaderFooterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F00592037081F00D24078 /* STableViewHeaderFooterProtocol.swift */; };
 		3C6F006220370DE200D24078 /* UITableView+WrapperUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F006120370DE200D24078 /* UITableView+WrapperUtils.swift */; };
+		3C6F0079203ADFA500D24078 /* EmptyStubTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F0077203ADFA500D24078 /* EmptyStubTableViewCell.swift */; };
 		3D1A89FDD6B579BAA92AD398E5C019F9 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958DAC978A9A102CE13A22CEC901B0D0 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		3E04D23B2995705A6106D41F3E3E4E33 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC0F538F33D488E14B47C13DBABA39 /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		41C783192F7ECD485C8C6384D30CBF11 /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73070C979CA9A6F0797AAECB256E4510 /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
@@ -237,6 +238,7 @@
 		3C6F00582037081F00D24078 /* STableViewCellProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = STableViewCellProtocol.swift; sourceTree = "<group>"; };
 		3C6F00592037081F00D24078 /* STableViewHeaderFooterProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = STableViewHeaderFooterProtocol.swift; sourceTree = "<group>"; };
 		3C6F006120370DE200D24078 /* UITableView+WrapperUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+WrapperUtils.swift"; sourceTree = "<group>"; };
+		3C6F0077203ADFA500D24078 /* EmptyStubTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStubTableViewCell.swift; sourceTree = "<group>"; };
 		3D3E90A311EC45483442C65061873F88 /* Behavior.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Behavior.swift; path = Sources/Quick/Behavior.swift; sourceTree = "<group>"; };
 		3EC0D5709FFACAECC8100A7EF637A64D /* Pods-SimpleTableViewWrapper_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SimpleTableViewWrapper_Example-umbrella.h"; sourceTree = "<group>"; };
 		3EF60AE5692DCBD265BD71581F760107 /* Pods-SimpleTableViewWrapper_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SimpleTableViewWrapper_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
@@ -450,6 +452,7 @@
 		3C6F004A203706B400D24078 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				3C6F0075203ADF8100D24078 /* Stubs */,
 				3C6F00502037081E00D24078 /* Utils */,
 				3C6F00522037081E00D24078 /* Models */,
 				3C6F00572037081F00D24078 /* Protocols */,
@@ -508,6 +511,22 @@
 				3C6F006120370DE200D24078 /* UITableView+WrapperUtils.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		3C6F0075203ADF8100D24078 /* Stubs */ = {
+			isa = PBXGroup;
+			children = (
+				3C6F0076203ADF8D00D24078 /* Cell */,
+			);
+			path = Stubs;
+			sourceTree = "<group>";
+		};
+		3C6F0076203ADF8D00D24078 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				3C6F0077203ADFA500D24078 /* EmptyStubTableViewCell.swift */,
+			);
+			path = Cell;
 			sourceTree = "<group>";
 		};
 		3E8BC20ACCF344DE105DDD582C0E4772 /* Pods */ = {
@@ -1141,6 +1160,7 @@
 			files = (
 				3C6F005B2037081F00D24078 /* STableViewItem.swift in Sources */,
 				3C6F005A2037081F00D24078 /* STableViewActionEnum.swift in Sources */,
+				3C6F0079203ADFA500D24078 /* EmptyStubTableViewCell.swift in Sources */,
 				3C6F005D2037081F00D24078 /* STableViewWrapper.swift in Sources */,
 				16B4DBF8E21A7EF18F5CB0E610898901 /* SimpleTableViewWrapper-dummy.m in Sources */,
 				3C6F005E2037081F00D24078 /* STableViewCellProtocol.swift in Sources */,

--- a/Example/SimpleTableViewWrapper.xcodeproj/project.pbxproj
+++ b/Example/SimpleTableViewWrapper.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		1EEB96D172E7F9B63D9DC113 /* Pods_SimpleTableViewWrapper_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED58356C66F05E04BBCE370E /* Pods_SimpleTableViewWrapper_Tests.framework */; };
+		3C40051920403B4F0080D9B5 /* SimpleTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C40051820403B4F0080D9B5 /* SimpleTableViewHeader.swift */; };
+		3C40051C20403B6A0080D9B5 /* SimpleTableViewHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3C40051B20403B6A0080D9B5 /* SimpleTableViewHeader.xib */; };
+		3C40051F204042E30080D9B5 /* SimpleTableViewFooter.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3C40051E204042E30080D9B5 /* SimpleTableViewFooter.xib */; };
+		3C400521204042ED0080D9B5 /* SimpleTableViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C400520204042ED0080D9B5 /* SimpleTableViewFooter.swift */; };
 		3C6F006D20371B3E00D24078 /* SimpleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F006C20371B3E00D24078 /* SimpleCell.swift */; };
 		3C6F007020371B9400D24078 /* SimpleItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F006F20371B9400D24078 /* SimpleItem.swift */; };
 		3C6F00732037364900D24078 /* SimpleTableViewCellWithNib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F00712037364900D24078 /* SimpleTableViewCellWithNib.swift */; };
@@ -33,6 +37,10 @@
 
 /* Begin PBXFileReference section */
 		17532ABB870AA2CD827537AC /* Pods-SimpleTableViewWrapper_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimpleTableViewWrapper_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-SimpleTableViewWrapper_Example/Pods-SimpleTableViewWrapper_Example.release.xcconfig"; sourceTree = "<group>"; };
+		3C40051820403B4F0080D9B5 /* SimpleTableViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTableViewHeader.swift; sourceTree = "<group>"; };
+		3C40051B20403B6A0080D9B5 /* SimpleTableViewHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SimpleTableViewHeader.xib; sourceTree = "<group>"; };
+		3C40051E204042E30080D9B5 /* SimpleTableViewFooter.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SimpleTableViewFooter.xib; sourceTree = "<group>"; };
+		3C400520204042ED0080D9B5 /* SimpleTableViewFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTableViewFooter.swift; sourceTree = "<group>"; };
 		3C6F006C20371B3E00D24078 /* SimpleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCell.swift; sourceTree = "<group>"; };
 		3C6F006F20371B9400D24078 /* SimpleItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleItem.swift; sourceTree = "<group>"; };
 		3C6F00712037364900D24078 /* SimpleTableViewCellWithNib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTableViewCellWithNib.swift; sourceTree = "<group>"; };
@@ -77,6 +85,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3C40051A20403B580080D9B5 /* Header */ = {
+			isa = PBXGroup;
+			children = (
+				3C40051820403B4F0080D9B5 /* SimpleTableViewHeader.swift */,
+				3C40051B20403B6A0080D9B5 /* SimpleTableViewHeader.xib */,
+			);
+			path = Header;
+			sourceTree = "<group>";
+		};
+		3C40051D204042C60080D9B5 /* Footer */ = {
+			isa = PBXGroup;
+			children = (
+				3C400520204042ED0080D9B5 /* SimpleTableViewFooter.swift */,
+				3C40051E204042E30080D9B5 /* SimpleTableViewFooter.xib */,
+			);
+			path = Footer;
+			sourceTree = "<group>";
+		};
 		3C6F006820371AFB00D24078 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -96,6 +122,8 @@
 		3C6F006A20371B2B00D24078 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				3C40051A20403B580080D9B5 /* Header */,
+				3C40051D204042C60080D9B5 /* Footer */,
 				3C6F006B20371B3000D24078 /* Cells */,
 			);
 			path = Views;
@@ -302,6 +330,8 @@
 			files = (
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
 				3C6F00742037364900D24078 /* SimpleTableViewCellWithNib.xib in Resources */,
+				3C40051F204042E30080D9B5 /* SimpleTableViewFooter.xib in Resources */,
+				3C40051C20403B6A0080D9B5 /* SimpleTableViewHeader.xib in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
 			);
@@ -431,7 +461,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				3C6F007020371B9400D24078 /* SimpleItem.swift in Sources */,
+				3C400521204042ED0080D9B5 /* SimpleTableViewFooter.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
+				3C40051920403B4F0080D9B5 /* SimpleTableViewHeader.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 				3C6F00732037364900D24078 /* SimpleTableViewCellWithNib.swift in Sources */,
 				3C6F006D20371B3E00D24078 /* SimpleCell.swift in Sources */,

--- a/Example/SimpleTableViewWrapper/View Controllers/ViewController.swift
+++ b/Example/SimpleTableViewWrapper/View Controllers/ViewController.swift
@@ -23,7 +23,13 @@ extension ViewController {
     private func sections() -> [STableViewSection] {
         let sections: [STableViewSection] = [
             STableViewSection(items: self.items()),
-            STableViewSection(items: self.items2())
+            STableViewSection(title: "Full Section Example",
+                              items: self.items2(),
+                              headerType: SimpleTableViewHeader.self,
+                              footerType: SimpleTableViewFooter.self),
+            STableViewSection(title: "Show Events Example",
+                              items: self.items3(),
+                              headerType: SimpleTableViewHeader.self)
         ]
         return sections
     }
@@ -51,6 +57,20 @@ extension ViewController {
             return item
         }
         return items
+    }
+    
+    private func items3() -> [STableViewItem] {
+        let item = SimpleItem(name: "Mad Item")
+        item.cellType = SimpleTableViewCellWithNib.self
+        item.onSelection = { [unowned self] selectedItem in
+            guard let it = selectedItem as? SimpleItem else { return }
+            self.showAlert(msg: "Selected \(it.name)")
+        }
+        item.onShow = { [unowned self] sitem in
+            guard let it = sitem as? SimpleItem else { return }
+            self.showAlert(msg: "An wild \(it.name) appeared!")
+        }
+        return [item]
     }
 }
 

--- a/Example/SimpleTableViewWrapper/Views/Footer/SimpleTableViewFooter.swift
+++ b/Example/SimpleTableViewWrapper/Views/Footer/SimpleTableViewFooter.swift
@@ -1,0 +1,17 @@
+//
+//  SimpleTableViewFooter.swift
+//  SimpleTableViewWrapper_Example
+//
+//  Created by Vitor Kawai Sala on 23/02/18.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import UIKit
+import SimpleTableViewWrapper
+
+final class SimpleTableViewFooter: UITableViewHeaderFooterView {
+}
+
+extension SimpleTableViewFooter: STableViewHeaderFooterNibProtocol {
+    static var viewHeight: CGFloat { return 30 }
+}

--- a/Example/SimpleTableViewWrapper/Views/Footer/SimpleTableViewFooter.xib
+++ b/Example/SimpleTableViewWrapper/Views/Footer/SimpleTableViewFooter.xib
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="SimpleTableViewFooter" customModule="SimpleTableViewWrapper_Example" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="30"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kv1-t1-YRc">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="30"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TABLE VIEW FOOTER" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ePb-ft-fPP">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="30"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                            <color key="textColor" red="0.93769127129999996" green="0.91776961089999998" blue="0.90913301710000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" red="0.78263842839999997" green="0.024115191049999998" blue="0.11587850619999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstItem="ePb-ft-fPP" firstAttribute="top" secondItem="Kv1-t1-YRc" secondAttribute="top" id="0Sv-gk-Ikw"/>
+                        <constraint firstAttribute="trailing" secondItem="ePb-ft-fPP" secondAttribute="trailing" id="He8-Ux-cTL"/>
+                        <constraint firstItem="ePb-ft-fPP" firstAttribute="leading" secondItem="Kv1-t1-YRc" secondAttribute="leading" id="JXL-ek-sb8"/>
+                        <constraint firstAttribute="bottom" secondItem="ePb-ft-fPP" secondAttribute="bottom" id="inX-Hn-9Pw"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Kv1-t1-YRc" secondAttribute="trailing" id="BDu-gv-Tog"/>
+                <constraint firstItem="Kv1-t1-YRc" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Xxh-Gw-3TH"/>
+                <constraint firstItem="Kv1-t1-YRc" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="cQC-cf-0Dt"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="Kv1-t1-YRc" secondAttribute="bottom" id="lba-Hb-doD"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+        </view>
+    </objects>
+</document>

--- a/Example/SimpleTableViewWrapper/Views/Header/SimpleTableViewHeader.swift
+++ b/Example/SimpleTableViewWrapper/Views/Header/SimpleTableViewHeader.swift
@@ -1,0 +1,25 @@
+//
+//  SimpleTableViewHeader.swift
+//  SimpleTableViewWrapper_Example
+//
+//  Created by Vitor Kawai Sala on 23/02/18.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import UIKit
+import SimpleTableViewWrapper
+
+final class SimpleTableViewHeader: UITableViewHeaderFooterView {
+    @IBOutlet private weak var lblTitle: UILabel!
+}
+
+extension SimpleTableViewHeader: STableViewHeaderFooterNibProtocol {
+    static var viewHeight: CGFloat { return 50 }
+    
+    func setHeaderFooter(forSection section: Int,
+                         fromTableViewHandler handler: STableViewWrapper,
+                         givenModel sectionModel: STableViewSection) {
+        
+        self.lblTitle.text = sectionModel.title
+    }
+}

--- a/Example/SimpleTableViewWrapper/Views/Header/SimpleTableViewHeader.xib
+++ b/Example/SimpleTableViewWrapper/Views/Header/SimpleTableViewHeader.xib
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="SimpleTableViewHeader" customModule="SimpleTableViewWrapper_Example" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3b1-8X-I6D">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tEG-xP-KdO">
+                            <rect key="frame" x="16" y="16" width="343" height="26"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                            <color key="textColor" red="0.93725490199999995" green="0.91372549020000005" blue="0.8980392157" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" red="0.0" green="0.36470588240000001" blue="0.58431372550000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="tEG-xP-KdO" secondAttribute="bottom" constant="8" id="ESz-5V-aiz"/>
+                        <constraint firstItem="tEG-xP-KdO" firstAttribute="leading" secondItem="3b1-8X-I6D" secondAttribute="leading" constant="16" id="XbH-BM-DfI"/>
+                        <constraint firstAttribute="trailing" secondItem="tEG-xP-KdO" secondAttribute="trailing" constant="16" id="bnI-MP-L2d"/>
+                        <constraint firstItem="tEG-xP-KdO" firstAttribute="top" secondItem="3b1-8X-I6D" secondAttribute="top" constant="16" id="mzZ-Ca-gcC"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <constraints>
+                <constraint firstItem="3b1-8X-I6D" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="Aad-wi-Cv1"/>
+                <constraint firstItem="3b1-8X-I6D" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Bl6-ya-9Qf"/>
+                <constraint firstAttribute="bottom" secondItem="3b1-8X-I6D" secondAttribute="bottom" id="FT6-MT-9WP"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="3b1-8X-I6D" secondAttribute="trailing" id="ehc-qx-dch"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <connections>
+                <outlet property="lblTitle" destination="tEG-xP-KdO" id="Hr1-tC-2bL"/>
+            </connections>
+        </view>
+    </objects>
+</document>

--- a/SimpleTableViewWrapper.podspec
+++ b/SimpleTableViewWrapper.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SimpleTableViewWrapper'
-  s.version          = '0.1.0'
+  s.version          = '0.2.0'
   s.summary          = 'A simple Table View Wrapper to create simple Table Views'
 
 # This description is used to generate tags and improve search results.

--- a/SimpleTableViewWrapper.podspec
+++ b/SimpleTableViewWrapper.podspec
@@ -39,6 +39,6 @@ Pod::Spec.new do |s|
   # }
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
-  # s.frameworks = 'UIKit', 'MapKit'
+  s.frameworks = 'UIKit'
   s.dependency 'Reusable', '~> 4.0.0'
 end

--- a/SimpleTableViewWrapper/Classes/Models/STableViewItem.swift
+++ b/SimpleTableViewWrapper/Classes/Models/STableViewItem.swift
@@ -21,7 +21,7 @@ open class STableViewItem {
     // MARK: Attributes
     /// The cell's reference that will be used to display this item's properties.
     ///
-    /// If nil, an fatalError will be throw.
+    /// If nil, an 0 height empty cell will be used instead.
     open var cellType: (UITableViewCell & STableViewCellProtocol).Type?
     
     /// An Bool marking if this item's cell should render the separator line.

--- a/SimpleTableViewWrapper/Classes/Models/STableViewItem.swift
+++ b/SimpleTableViewWrapper/Classes/Models/STableViewItem.swift
@@ -11,11 +11,20 @@ public typealias STableViewItemAction = ((STableViewItem) -> Void)
 
 open class STableViewItem {
     // MARK: Actions
+    
+    /// The selection closure. This closure will be called when user select the cell containing this item.
     open var onSelection: STableViewItemAction?
+    
+    /// The show closure. This closure will be called when the cell, contaning this item, will be displayed to user's screen.
     open var onShow: STableViewItemAction?
     
     // MARK: Attributes
+    /// The cell's reference that will be used to display this item's properties.
+    ///
+    /// If nil, an fatalError will be throw.
     open var cellType: (UITableViewCell & STableViewCellProtocol).Type?
+    
+    /// An Bool marking if this item's cell should render the separator line.
     open var isSeparatorVisible: Bool
     
     public init(cellType: (UITableViewCell & STableViewCellProtocol).Type? = nil,

--- a/SimpleTableViewWrapper/Classes/Models/STableViewItem.swift
+++ b/SimpleTableViewWrapper/Classes/Models/STableViewItem.swift
@@ -18,8 +18,8 @@ open class STableViewItem {
     open var cellType: (UITableViewCell & STableViewCellProtocol).Type?
     open var isSeparatorVisible: Bool
     
-    public init<T: UITableViewCell>(cellType: T.Type,
-                                    isSeparatorVisible: Bool = true) where T: STableViewCellProtocol {
+    public init(cellType: (UITableViewCell & STableViewCellProtocol).Type? = nil,
+                isSeparatorVisible: Bool = true) {
 
         self.cellType = cellType
         self.isSeparatorVisible = isSeparatorVisible

--- a/SimpleTableViewWrapper/Classes/Models/STableViewSection.swift
+++ b/SimpleTableViewWrapper/Classes/Models/STableViewSection.swift
@@ -8,10 +8,18 @@
 import UIKit
 
 open class STableViewSection {
+    /// The items contained on this Section
     public var items: [STableViewItem] = []
     
+    /// The header's view reference.
     public var headerType: (UITableViewHeaderFooterView & STableViewHeaderFooterProtocol).Type?
+    
+    /// The footer's view reference.
     public var footerType: (UITableViewHeaderFooterView & STableViewHeaderFooterProtocol).Type?
+    
+    /// An convenience property.
+    ///
+    /// it won't be used by the wrapper unless your header/footer use this property for something.
     public var title: String?
     
     public init(title: String? = nil,

--- a/SimpleTableViewWrapper/Classes/Protocols/STableViewCellProtocol.swift
+++ b/SimpleTableViewWrapper/Classes/Protocols/STableViewCellProtocol.swift
@@ -9,11 +9,31 @@ import UIKit
 import Reusable
 
 public protocol STableViewCellProtocol: Reusable {
+    /// The cell's height.
+    ///
+    /// If this propety is not overriden, it will default to
+    /// **UITableViewAutomaticDimension**
     static var cellHeight: CGFloat { get }
     
+    /// Protocol function to allow cell's properties to be safely setted.
+    ///
+    /// This function will be called on tableView(tableView:, cellForRowAt:) cycle
+    /// - Parameter item: The containing item setted at IndexPath
     func setCell(item: STableViewItem)
+    
+    /// This function will be called on tableView(tableView:, willDisplay:, forRowAt: )
+    ///
+    /// Use this function to make final layout adjustments for cells that need to adapt
+    /// to constraints before its properties get setted through setCell(item: )
     func layoutCell()
     
+    /// An helper function to cells that should not show separator lines.
+    ///
+    /// It already have an default implementation to adjust its
+    /// EdgeInsets to be offscreen.
+    /// - Parameters:
+    ///   - hidden: An *Bool* indicating if the indicator should be hidden
+    ///   - backgroundColor: An **UIColor** containing the **ViewController**'s background color
     func separator(hidden: Bool, backgroundColor: UIColor)
 }
 

--- a/SimpleTableViewWrapper/Classes/Protocols/STableViewHeaderFooterProtocol.swift
+++ b/SimpleTableViewWrapper/Classes/Protocols/STableViewHeaderFooterProtocol.swift
@@ -9,7 +9,15 @@ import UIKit
 import Reusable
 
 public protocol STableViewHeaderFooterProtocol: Reusable {
+    /// The height of the implementing view.
     static var viewHeight: CGFloat { get }
+    
+    /// Function to set Header/Footer's properties. This will be called on
+    /// tableView(tableView:, viewForHeaderInSection: ) or tableView(tableView:, viewForFooterInSection: )
+    /// - Parameters:
+    ///   - section: The section that this header/footer will be displayed
+    ///   - handler: The **STableViewWrapper** that are requesting this header/footer
+    ///   - sectionModel: The Section model that are setted on DataSource.
     func setHeaderFooter(forSection section: Int,
                          fromTableViewHandler handler: STableViewWrapper,
                          givenModel sectionModel: STableViewSection)

--- a/SimpleTableViewWrapper/Classes/Protocols/STableViewHeaderFooterProtocol.swift
+++ b/SimpleTableViewWrapper/Classes/Protocols/STableViewHeaderFooterProtocol.swift
@@ -23,4 +23,10 @@ public protocol STableViewHeaderFooterProtocol: Reusable {
                          givenModel sectionModel: STableViewSection)
 }
 
-public protocol STableViewHeaderFooterNibProtocol: STableViewHeaderFooterProtocol, NibLoadable {}
+public extension STableViewHeaderFooterProtocol {
+    func setHeaderFooter(forSection section: Int,
+                         fromTableViewHandler handler: STableViewWrapper,
+                         givenModel sectionModel: STableViewSection) {}
+}
+
+public typealias STableViewHeaderFooterNibProtocol = STableViewHeaderFooterProtocol & NibLoadable

--- a/SimpleTableViewWrapper/Classes/Stubs/Cell/EmptyStubTableViewCell.swift
+++ b/SimpleTableViewWrapper/Classes/Stubs/Cell/EmptyStubTableViewCell.swift
@@ -1,0 +1,13 @@
+//
+//  EmptyStubTableViewCell.swift
+//  SimpleTableViewWrapper
+//
+//  Created by Vitor Kawai Sala on 19/02/18.
+//
+
+import UIKit
+
+public final class EmptyStubTableViewCell: UITableViewCell {}
+extension EmptyStubTableViewCell: STableViewCellProtocol {
+    public static var cellHeight: CGFloat { return 0 }
+}

--- a/SimpleTableViewWrapper/Classes/TableViewWrapper/STableViewWrapper.swift
+++ b/SimpleTableViewWrapper/Classes/TableViewWrapper/STableViewWrapper.swift
@@ -16,6 +16,7 @@ private enum ViewType {
 public class STableViewWrapper: NSObject {
     private weak var tableView: UITableView?
     
+    /// The sections contained by this wrapper
     public var sections: [STableViewSection]
     
     public var backgroundColor: UIColor {
@@ -34,6 +35,12 @@ public class STableViewWrapper: NSObject {
 }
 
 extension STableViewWrapper {
+    
+    /// The setup function.
+    ///
+    /// This function must be called in order to the TableView be displayed correctly
+    ///
+    /// - Parameter tableView: The **UITableView** that will be used.
     public func setup(tableView: UITableView) {
         self.tableView = tableView
         
@@ -44,6 +51,14 @@ extension STableViewWrapper {
         tableView.estimatedRowHeight = 150
         
         self.register(sections: self.sections, for: tableView)
+    }
+    
+    /// Reaload TableView's datasource, use this function instead of native's TableView to ensure
+    /// that all items's cell are correctly registered
+    public func reloadData() {
+        guard let tableView = self.tableView else { return }
+        self.register(sections: self.sections, for: tableView)
+        tableView.reloadData()
     }
     
     private func register(sections: [STableViewSection], for tableView: UITableView) {

--- a/SimpleTableViewWrapper/Classes/TableViewWrapper/STableViewWrapper.swift
+++ b/SimpleTableViewWrapper/Classes/TableViewWrapper/STableViewWrapper.swift
@@ -60,22 +60,36 @@ extension STableViewWrapper {
         self.register(sections: self.sections, for: tableView)
         tableView.reloadData()
     }
+}
+
+extension STableViewWrapper {
+    private func registerHeaderFooter(forSection section: STableViewSection, for tableView: UITableView) {
+        if let header = section.headerType {
+            tableView.register(headerFooter: header)
+        }
+        if let footer = section.footerType {
+            tableView.register(headerFooter: footer)
+        }
+    }
+    
+    private func register(items: [STableViewItem], for tableView: UITableView) {
+        items.forEach {
+            if let cellType = $0.cellType {
+                tableView.register(cell: cellType)
+            }
+        }
+    }
+    
+    private func registerOthersElements(for tableView: UITableView) {
+        tableView.register(cell: EmptyStubTableViewCell.self)
+    }
     
     private func register(sections: [STableViewSection], for tableView: UITableView) {
         sections.forEach {
-            if let header = $0.headerType {
-                tableView.register(headerFooter: header)
-            }
-            if let footer = $0.footerType {
-                tableView.register(headerFooter: footer)
-            }
-            
-            $0.items.forEach {
-                if let cellType = $0.cellType {
-                    tableView.register(cell: cellType)
-                }
-            }
+            self.registerHeaderFooter(forSection: $0, for: tableView)
+            self.register(items: $0.items, for: tableView)
         }
+        self.registerOthersElements(for: tableView)
     }
 }
 

--- a/SimpleTableViewWrapper/Classes/TableViewWrapper/STableViewWrapper.swift
+++ b/SimpleTableViewWrapper/Classes/TableViewWrapper/STableViewWrapper.swift
@@ -21,7 +21,9 @@ public class STableViewWrapper: NSObject {
     
     public var backgroundColor: UIColor {
         get {
-            return self.tableView?.backgroundColor ?? .clear
+            return self.tableView?.backgroundColor ??
+                self.tableView?.superview?.backgroundColor ??
+                .clear
         }
         set {
             self.tableView?.backgroundColor = newValue

--- a/SimpleTableViewWrapper/Classes/Utils/Extensions/UITableView+WrapperUtils.swift
+++ b/SimpleTableViewWrapper/Classes/Utils/Extensions/UITableView+WrapperUtils.swift
@@ -17,11 +17,11 @@ extension UITableView {
     }
     
     final func register(headerFooter: (UITableViewHeaderFooterView & STableViewHeaderFooterProtocol).Type) {
-        if let nibLoadable = headerFooter as? STableViewCellNibProtocol.Type {
-            self.register(nibLoadable.nib, forCellReuseIdentifier: nibLoadable.reuseIdentifier)
+        if let nibLoadable = headerFooter as? STableViewHeaderFooterNibProtocol.Type {
+            self.register(nibLoadable.nib, forHeaderFooterViewReuseIdentifier: nibLoadable.reuseIdentifier)
             
         } else {
-            self.register(headerFooter, forCellReuseIdentifier: headerFooter.reuseIdentifier)
+            self.register(headerFooter, forHeaderFooterViewReuseIdentifier: headerFooter.reuseIdentifier)
         }
     }
     

--- a/SimpleTableViewWrapper/Classes/Utils/Extensions/UITableView+WrapperUtils.swift
+++ b/SimpleTableViewWrapper/Classes/Utils/Extensions/UITableView+WrapperUtils.swift
@@ -27,9 +27,7 @@ extension UITableView {
     
     final func dequeueReusableCell(for item: STableViewItem, at indexPath: IndexPath) -> (UITableViewCell & STableViewCellProtocol) {
         
-        guard let cellType = item.cellType else {
-            fatalError("Item don't contain any cell")
-        }
+        let cellType = item.cellType ?? EmptyStubTableViewCell.self
         guard let cell = self.dequeueReusableCell(withIdentifier: cellType.reuseIdentifier, for: indexPath) as? (UITableViewCell & STableViewCellProtocol) else {
             
             fatalError("Cell must conform to either STableViewCellProtocol or STableViewCellNibProtocol")

--- a/SimpleTableViewWrapper/Classes/Utils/STableViewActionEnum.swift
+++ b/SimpleTableViewWrapper/Classes/Utils/STableViewActionEnum.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum ItemActionType {
+internal enum ItemActionType {
     case selection
     case show
 }


### PR DESCRIPTION
Changelog:
- Added:
   - Code documentation.
- Changed: 
   - Item's cellType is no longer needed to be setted on init. If no cellType was setted, TableViewWrapper will use an 0 height empty cell stub.
   - Color fallback for cells with hidden separator lines. Will try to use TableView's background color, then back to TableView's superview background color and, finally, UIColor.clear if any of previous color is nil.
- Fixed: 
   - problems with STableViewHeaderFooterNibProtocol that caused an crash on view register.